### PR TITLE
Adding new binary file and fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ python3 -m venv venv-img
 ```
 Install necessary depedencies:
 ```
-pip install -r requirements.txt
+pip3 install -r requirements.txt
 ```
 
 Deactivate virtualenv, and zip site packages and change to starting dir: 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The \*.zip in `binary-zip` directory contains the whole project ready to deploy 
   
 ### How to prepare a zip for Lambda deploy:
 
+NOTE: The example is tested and works with `python3.6`! There **are issues** with `python 3.7`.
+
 First you need to create a clean virtual env and activate it:
 
 ```


### PR DESCRIPTION
It seems that typo (pip instead pip3) wrongly packed the zip package ready for Amazon Lambda. This should fix the issue.